### PR TITLE
Update Makefile.in

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -603,7 +603,7 @@ uninstall-am: uninstall-binPROGRAMS
 
 
 install-data-local:
-	$(INSTALL_DATA) urlview.man $(mandir)/man1/urlview.1
+	$(INSTALL_DATA) urlview.man $(DESTDIR)$(mandir)/man1/urlview.1
 
 # how to create a target for uninstall-data-local???
 


### PR DESCRIPTION
$(DESTDIR) is needed in front of $(mandir), just as
it is used elsewhere in front of $(bindir), e.g.:

$(mkinstalldirs) $(DESTDIR)$(bindir)
