### PR TITLE
Add QUITONLAUNCH option to urlview configure file

### DIFF
--- a/sample.urlview
+++ b/sample.urlview
@@ -27,3 +27,6 @@ REGEXP (((http|https|ftp|gopher)|mailto)[.:][^ >"\t]*|www\.[-a-z0-9.]+)[^ .,;\t>
 #COMMAND netscape -remote 'openURL(%s)'
 COMMAND url_handler.sh
 
+
+# Quit urlview after launch
+#QUITONLAUNCH

--- a/urlview.c
+++ b/urlview.c
@@ -174,6 +174,7 @@ int main (int argc, char **argv)
   int oldcurrent = 0;
   int current = 0;
   int done = 0;
+  int quitonlaunch = 0;
   int redraw = FULL;
   int urlcount = 0;
   int urlcheck = 0;
@@ -279,6 +280,10 @@ int main (int argc, char **argv)
       {
 	expert = 1;
       }
+	  else if (strcmp ("QUITONLAUNCH\n", buf) == 0)
+	  {
+	quitonlaunch = 1;
+	  }
       else
       {
 	printf ("Unknown command: %s", buf);
@@ -625,6 +630,7 @@ into a line of its own in your \n\
 	      ((part = strtok(NULL, ":")) != NULL);
 	  free(tmpbuf);
 	}
+	done = quitonlaunch;
 	move (LINES - 1, 0);
 	clrtoeol ();
 	break;

--- a/urlview.man
+++ b/urlview.man
@@ -79,6 +79,9 @@ explicitly excludes single quotes.)
 WRAP  \fIchoice\fP
 Enable or disable URL wrapping. Valid values for \fIchoice\fP are: yes, no (case insensitive).
 If this option is not supplied, the default behaviour is to disable wrapping.
+.TP
+QUITONLAUNCH
+Will cause urlview to quit after you launch a URL.
 .SH FILES
 .PP
 .IP "/etc/urlview/system.urlview"

--- a/urlview.sgml
+++ b/urlview.sgml
@@ -58,6 +58,11 @@ messages:
 </verb>
 If you pass this URL to your shell, it could have nasty consequences.
 
+<p>
+QUITONLAUNCH
+<p>
+Will cause urlview to quit after you launch a URL.
+
 <sect1>FILES
 <p>
 <descrip>


### PR DESCRIPTION
Quit urlview after you launch a URL.  Useful when most emails only have
one (or one relevant) URL.
