### PR TITLE
Adjust keybindings for dvorak layout

### DIFF
--- a/urlview.c
+++ b/urlview.c
@@ -487,11 +487,11 @@ into a line of its own in your \n\
     {
       case 'q':
       case 'x':
-      case 'h':
 	done = 1;
 	break;
       case KEY_DOWN:
       case 'j':
+      case 'h':
 	if (current < urlcount - 1)
 	{
 	  current++;
@@ -518,6 +518,7 @@ into a line of its own in your \n\
 	break;
       case KEY_UP:
       case 'k':
+      case 't':
 	if (current)
 	{
 	  current--;


### PR DESCRIPTION
h and t on dvorak layout are located where j and k on qwerty.
So following change will provide additional bindings removing h as exit command.
For dvorak users it is nice thing, and not having h as exit is
not such big thing probably. What do you think? Is it ok with you?
