### PR TITLE
Initial pcre support

### DIFF
--- a/configure
+++ b/configure
@@ -709,6 +709,7 @@ ac_user_opts='
 enable_option_checking
 enable_dependency_tracking
 with_slang
+with_pcre
 with_rx
 enable_warnings
 '
@@ -1341,6 +1342,7 @@ Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
   --with-slang=DIR      use S-Lang instead of curses
+  --with-pcre=DIR       use pcre regex
   --with-rx=DIR           where to find librx
 
 Some influential environment variables:
@@ -4628,6 +4630,66 @@ fi
 
 fi
 
+
+fi
+
+
+
+# Check whether --with-pcre was given.
+if test "${with_pcre+set}" = set; then :
+  withval=$with_pcre; $as_echo "#define USE_PCRE 1" >>confdefs.h
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for regexec in -lpcre" >&5
+$as_echo_n "checking for regexec in -lpcre... " >&6; }
+if ${ac_cv_lib_pcre_regexec+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lpcre  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char regexec ();
+int
+main ()
+{
+return regexec ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_pcre_regexec=yes
+else
+  ac_cv_lib_pcre_regexec=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_pcre_regexec" >&5
+$as_echo "$ac_cv_lib_pcre_regexec" >&6; }
+if test "x$ac_cv_lib_pcre_regexec" = xyes; then :
+  LIBS="$LIBS -lpcre"
+fi
+
+  for ac_header in pcre.h
+do :
+  ac_fn_c_check_header_mongrel "$LINENO" "pcre.h" "ac_cv_header_pcre_h" "$ac_includes_default"
+if test "x$ac_cv_header_pcre_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_PCRE_H 1
+_ACEOF
+
+fi
+
+done
 
 fi
 

--- a/configure.in
+++ b/configure.in
@@ -32,6 +32,11 @@ AC_ARG_WITH(slang, [  --with-slang[=DIR]      use S-Lang instead of curses],
 	AC_CHECK_HEADER(ncursesw/curses.h, [CPPFLAGS="$CPPFLAGS -I/usr/include/ncursesw"],
 		[AC_CHECK_HEADER(ncurses/curses.h, [CPPFLAGS="$CPPFLAGS -I/usr/include/ncurses"])])])
 
+AC_ARG_WITH(pcre, [  --with-pcre[=DIR]       use pcre regex],
+  [AC_DEFINE(USE_PCRE)]
+  [AC_CHECK_LIB(pcre, regexec, [LIBS="$LIBS -lpcre"])]
+  AC_CHECK_HEADERS(pcre.h))
+
 AC_REPLACE_FUNCS(snprintf)
 
 AC_ARG_WITH(rx, [  --with-rx=DIR           where to find librx],

--- a/urlview.c
+++ b/urlview.c
@@ -69,81 +69,81 @@ extern int mutt_enter_string (unsigned char *buf, size_t buflen, int y, int x,
 
 void search_forward (char *search, int urlcount, char **url, int *redraw, int *current, int *top)
 {
-  regex_t rx;
-  int i, j;
-
-  if (strlen(search) == 0 || *search == '\n')
-  {
-    move (LINES - 1, 0);
-    clrtoeol ();
-    *redraw = MOTION;
-  } 
-  else
-  {
-    if ( (j = regcomp (&rx, search, REG_EXTENDED | REG_ICASE | REG_NEWLINE)) )
-    {
-      regerror (j, &rx, search, sizeof (search));
-      regfree (&rx);
-      puts (search);
-    }
-    for (i = *current + 1; i < urlcount; i++)
-    {
-      if (regexec (&rx, url[i], 0, NULL, 0) == 0)
-      {
-	*current = i;
-	if (*current < *top || *current > *top + PAGELEN -1)
-	{
-	  *top = *current - *current % PAGELEN - 1;
-	}
-	i = urlcount;
-      }
-    }
-    move (LINES - 1, 0);
-    clrtoeol ();
-    *redraw = INDEX;
-    regfree (&rx);
-  }
+  // regex_t rx;
+  // int i, j;
+  //
+  // if (strlen(search) == 0 || *search == '\n')
+  // {
+  //   move (LINES - 1, 0);
+  //   clrtoeol ();
+  //   *redraw = MOTION;
+  // }
+  // else
+  // {
+  //   if ( (j = regcomp (&rx, search, REG_EXTENDED | REG_ICASE | REG_NEWLINE)) )
+  //   {
+  //     regerror (j, &rx, search, sizeof (search));
+  //     regfree (&rx);
+  //     puts (search);
+  //   }
+  //   for (i = *current + 1; i < urlcount; i++)
+  //   {
+  //     if (regexec (&rx, url[i], 0, NULL, 0) == 0)
+  //     {
+// *current = i;
+// if (*current < *top || *current > *top + PAGELEN -1)
+// {
+  // *top = *current - *current % PAGELEN - 1;
+// }
+// i = urlcount;
+  //     }
+  //   }
+  //   move (LINES - 1, 0);
+  //   clrtoeol ();
+  //   *redraw = INDEX;
+  //   regfree (&rx);
+  // }
 }
 
 void search_backward (char *search, int urlcount, char **url, int *redraw, int *current, int *top)
 {
-  regex_t rx;
-  int i, j;
-
-  (void)urlcount; /*unused*/
-  if (strlen(search) == 0 || *search == '\n')
-  {
-    move (LINES - 1, 0);
-    clrtoeol ();
-    *redraw = MOTION;
-  } 
-  else
-  {
-    if ((j = regcomp (&rx, search, REG_EXTENDED | REG_ICASE | REG_NEWLINE)))
-    {
-      regerror (j, &rx, search, sizeof (search));
-      regfree (&rx);
-      puts (search);
-    }
-    for (i = *current - 1; i >= 0; i--)
-    {
-      if (regexec (&rx, url[i], 0, NULL, 0) == 0)
-      {
-	*current = i;
-	if (*current < *top || *current > *top + PAGELEN -1)
-	{
-	  *top = *current - *current % PAGELEN - 1;
-	  if (*top < 0)
-	    *top = 0;
-	}
-	i = 0;
-      }
-    }
-    move (LINES - 1, 0);
-    clrtoeol ();
-    *redraw = INDEX;
-    regfree (&rx);
-  }
+  // regex_t rx;
+  // int i, j;
+  //
+  // (void)urlcount; /*unused*/
+  // if (strlen(search) == 0 || *search == '\n')
+  // {
+  //   move (LINES - 1, 0);
+  //   clrtoeol ();
+  //   *redraw = MOTION;
+  // }
+  // else
+  // {
+  //   if ((j = regcomp (&rx, search, REG_EXTENDED | REG_ICASE | REG_NEWLINE)))
+  //   {
+  //     regerror (j, &rx, search, sizeof (search));
+  //     regfree (&rx);
+  //     puts (search);
+  //   }
+  //   for (i = *current - 1; i >= 0; i--)
+  //   {
+  //     if (regexec (&rx, url[i], 0, NULL, 0) == 0)
+  //     {
+// *current = i;
+// if (*current < *top || *current > *top + PAGELEN -1)
+// {
+  // *top = *current - *current % PAGELEN - 1;
+  // if (*top < 0)
+    // *top = 0;
+// }
+// i = 0;
+  //     }
+  //   }
+  //   move (LINES - 1, 0);
+  //   clrtoeol ();
+  //   *redraw = INDEX;
+  //   regfree (&rx);
+  // }
 }
  
 int main (int argc, char **argv)

--- a/urlview.c
+++ b/urlview.c
@@ -41,10 +41,14 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 
+#ifdef HAVE_PCRE_H
+#include <pcre.h>
+#else
 #ifdef HAVE_REGEX_H
 #include <regex.h>
 #else
 #include <rx/rxposix.h>
+#endif
 #endif
 
 #include "quote.h"
@@ -154,8 +158,13 @@ int main (int argc, char **argv)
   SCREEN *scr;
 #endif
   FILE *fp;
+#if HAVE_PCRE_H
+  pcre *rx;
+  int ovector[30];
+#else
   regex_t rx;
   regmatch_t match;
+#endif
   char buf[1024];
   char command[1024];
   char regexp[1024];
@@ -327,10 +336,19 @@ into a line of its own in your \n\
   
   /*** compile the regexp ***/
 
-  if ((i = regcomp (&rx, regexp, REG_EXTENDED | REG_ICASE | REG_NEWLINE)))
-  {
-    regerror (i, &rx, buf, sizeof (buf));
-    regfree (&rx);
+#if HAVE_PCRE_H
+	const char *regex_error;
+	int error_offset;
+	rx = pcre_compile(regexp, 0, &regex_error, &error_offset, NULL);
+	if (rx == NULL)
+	{
+		printf("ERROR: Could not compile '%s': %s\n", regexp, regex_error);
+#else
+	if ((i = regcomp (&rx, regexp, REG_EXTENDED | REG_ICASE | REG_NEWLINE)))
+	{
+		regerror (i, &rx, buf, sizeof (buf));
+		regfree (&rx);
+#endif
     puts (buf);
     exit (1);
   }
@@ -365,9 +383,21 @@ into a line of its own in your \n\
     {
 	  --startline;
       offset = 0;
-      while (regexec (&rx, buf + offset, 1, &match, offset ? REG_NOTBOL : 0) == 0)
-      {
-	len = match.rm_eo - match.rm_so;
+
+#if HAVE_PCRE_H
+    int length = strlen(buf);
+    while (pcre_exec (rx, NULL, buf + offset, length - offset, 0, offset ? PCRE_NOTBOL : 0, ovector, 30) >= 0)
+    {
+      int match_start = ovector[0];
+      int match_end = ovector[1];
+#else
+    while (regexec (&rx, buf + offset, 1, &match, offset ? REG_NOTBOL : 0) == 0)
+    {
+      int match_start = match.rm_so;
+      int match_end = match.rm_eo;
+#endif
+
+	len = match_end - match_start;
         if (urlcount >= urlsize)
 	{
 	  void *urltmp;
@@ -385,7 +415,7 @@ into a line of its own in your \n\
 	  }
 	}
 	url[urlcount] = malloc (len + 1);
-	memcpy (url[urlcount], buf + match.rm_so + offset, len);
+	memcpy (url[urlcount], buf + match_start + offset, len);
 	url[urlcount][len] = 0;
 	for (urlcheck=0; urlcheck < urlcount; urlcheck++)
 	{
@@ -398,7 +428,7 @@ into a line of its own in your \n\
 	if (current < 0 && startline <= 0)
 	  current = urlcount;
 	urlcount++;
-	offset += match.rm_eo;
+	offset += match_end;
       }
     }
   got_urls:
@@ -407,7 +437,11 @@ into a line of its own in your \n\
       break;
   }
 
-  regfree (&rx);
+#if HAVE_PCRE_H
+	pcre_free (rx);
+#else
+	regfree (&rx);
+#endif
 
   if (!urlcount)
   {


### PR DESCRIPTION
This PR is part of the way to closing https://github.com/sigpipe/urlview/issues/4

pcre support allows us to use super complex regular expressions like [this one](https://daringfireball.net/2010/07/improved_regex_for_matching_urls) to find URLs, which handles a lot of otherwise unhandled edge cases.

This PR has disabled forward and backwards searching support temporarily because 1) I want to check and see how everyone feels about the approach to this 2) I can't tell how this feature is actually suppose to work since it doesn't seem to do anything on my system.

Let me know your thoughts so we can work together to get this merged!
