### PR TITLE
urlview: use a 4k buffer

### DIFF
--- a/urlview.c
+++ b/urlview.c
@@ -156,7 +156,7 @@ int main (int argc, char **argv)
   FILE *fp;
   regex_t rx;
   regmatch_t match;
-  char buf[1024];
+  char buf[4096];
   char command[1024];
   char regexp[1024];
   char search[1024];


### PR DESCRIPTION
Unsubscribe links are pretty big these days and the 1k buffer isn't big
enough.

---
Dynamic memory here would be far better, but that's a lot more work than I have time for given the problem at hand.