### PR TITLE
Change local config to $HOME/.config

### DIFF
--- a/sample.urlview
+++ b/sample.urlview
@@ -2,7 +2,7 @@
 # Urlview configuration file.
 # man urlview  <Man page>
 #
-# Put this file in: $HOME/.urlview
+# Put this file in: $HOME/.config/urlview/config
 # Put url_handler.sh in: /usr/bin
 #
 # You can call 'urlview' while in 'mutt' by pressing the Ctrl b keys.

--- a/urlview.c
+++ b/urlview.c
@@ -196,7 +196,7 @@ int main (int argc, char **argv)
   /*** read the initialization file ***/
 
   pw = getpwuid (getuid ());
-  snprintf (buf, sizeof (buf), "%s/.urlview", pw->pw_dir);
+	snprintf (buf, sizeof (buf), "%s/.config/urlview/config", pw->pw_dir);
 
   /*** Check for users rc-file ***/
   if (stat (buf,&stat_buf) == -1)
@@ -320,7 +320,7 @@ in error; please read the manual page\n\
 for details. If you really want to use\n\
 this command, please put the word EXPERT\n\
 into a line of its own in your \n\
-~/.urlview file.\n\
+~/..config/urlview/config file.\n\
 ");
     exit (1);
   }

--- a/urlview.man
+++ b/urlview.man
@@ -31,7 +31,7 @@ specific item.
 .PP
 .B urlview
 attempts to read 
-.I ~/.urlview
+.I ~/.config/urlview/config
 upon startup.  If this file
 doesn't exist, it will try to read a system wide file 
 in 
@@ -86,7 +86,7 @@ Will cause urlview to quit after you launch a URL.
 .PP
 .IP "/etc/urlview/system.urlview"
 system-wide urlview configuration file
-.IP "~/.urlview"
+.IP "~/.config/urlview/config"
 urlview configuration file
 .SH ENVIRONMENT
 If the environment variable BROWSER is set to a browser command, or a


### PR DESCRIPTION
To ~/.config/urlview/config

Its not XDG_BASE_DIR compliant because I don't check the variable value. I think that adding dependencies on a library to do that is not needed since most people use $HOME/.config/ as their XDG_CONFIG_HOME (it defaults to it unless overwritten). 